### PR TITLE
Fix Simplenote install

### DIFF
--- a/okio/js/src/main/kotlin/okio/ByteString.kt
+++ b/okio/js/src/main/kotlin/okio/ByteString.kt
@@ -30,6 +30,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -152,19 +153,9 @@ internal actual constructor(
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
-      fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(), fromIndex)
 
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/SegmentedByteStringBenchmark.java
+++ b/okio/jvm/src/jmh/java/com/squareup/okio/benchmarks/SegmentedByteStringBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Square, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.okio.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okio.Buffer;
+import okio.ByteString;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class SegmentedByteStringBenchmark {
+
+  private static final ByteString UNKNOWN = ByteString.encodeUtf8("UNKNOWN");
+  private static final ByteString SEARCH = ByteString.encodeUtf8("tell");
+
+  @Param({"20", "2000", "200000"})
+  int length;
+
+  private ByteString byteString;
+
+  @Setup
+  public void setup() {
+    String part =
+        "Um, I'll tell you the problem with the scientific power that you're using here, "
+            + "it didn't require any discipline to attain it. You read what others had done and you "
+            + "took the next step. You didn't earn the knowledge for yourselves, so you don't take any "
+            + "responsibility for it. You stood on the shoulders of geniuses to accomplish something "
+            + "as fast as you could, and before you even knew what you had, you patented it, and "
+            + "packaged it, and slapped it on a plastic lunchbox, and now you're selling it, you wanna "
+            + "sell it.";
+
+    Buffer buffer = new Buffer();
+    while (buffer.size() < length) {
+      buffer.writeUtf8(part);
+    }
+    byteString = buffer.snapshot(length);
+  }
+
+  @Benchmark
+  public ByteString substring() {
+    return byteString.substring(1, byteString.size() - 1);
+  }
+
+  @Benchmark
+  public ByteString md5() {
+    return byteString.md5();
+  }
+
+  @Benchmark
+  public int indexOfUnknown() {
+    return byteString.indexOf(UNKNOWN);
+  }
+
+  @Benchmark
+  public int lastIndexOfUnknown() {
+    return byteString.lastIndexOf(UNKNOWN);
+  }
+
+  @Benchmark
+  public int indexOfEarly() {
+    return byteString.indexOf(SEARCH);
+  }
+
+  @Benchmark
+  public int lastIndexOfEarly() {
+    return byteString.lastIndexOf(SEARCH);
+  }
+
+  public static void main(String[] args) throws IOException, RunnerException {
+    Main.main(new String[] {SegmentedByteStringBenchmark.class.getName()});
+  }
+}

--- a/okio/jvm/src/main/java/okio/Buffer.kt
+++ b/okio/jvm/src/main/java/okio/Buffer.kt
@@ -1470,7 +1470,8 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
       // Scan through the segments, searching for the lead byte. Each time that is found, delegate
       // to rangeEquals() to check for a complete match.
-      val b0 = bytes[0]
+      val targetByteArray = bytes.internalArray()
+      val b0 = targetByteArray[0]
       val bytesSize = bytes.size
       val resultLimit = size - bytesSize + 1L
       while (offset < resultLimit) {
@@ -1478,7 +1479,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
         val data = s.data
         val segmentLimit = minOf(s.limit, s.pos + resultLimit - offset).toInt()
         for (pos in (s.pos + fromIndex - offset).toInt() until segmentLimit) {
-          if (data[pos] == b0 && rangeEquals(s, pos + 1, bytes.internalArray(), 1, bytesSize)) {
+          if (data[pos] == b0 && rangeEquals(s, pos + 1, targetByteArray, 1, bytesSize)) {
             return pos - s.pos + offset
           }
         }
@@ -1754,7 +1755,7 @@ class Buffer : BufferedSource, BufferedSink, Cloneable, ByteChannel {
 
   /** Returns an immutable copy of the first `byteCount` bytes of this buffer as a byte string. */
   fun snapshot(byteCount: Int): ByteString {
-    return if (byteCount == 0) ByteString.EMPTY else SegmentedByteString(this, byteCount)
+    return if (byteCount == 0) ByteString.EMPTY else SegmentedByteString.of(this, byteCount)
   }
 
   @JvmOverloads fun readUnsafe(unsafeCursor: UnsafeCursor = UnsafeCursor()): UnsafeCursor {

--- a/okio/jvm/src/main/java/okio/ByteString.kt
+++ b/okio/jvm/src/main/java/okio/ByteString.kt
@@ -30,6 +30,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -98,7 +99,7 @@ internal actual constructor(
   /** Returns the 512-bit SHA-512 hash of this byte string.  */
   open fun sha512() = digest("SHA-512")
 
-  private fun digest(algorithm: String) =
+  internal open fun digest(algorithm: String) =
       ByteString(MessageDigest.getInstance(algorithm).digest(data))
 
   /** Returns the 160-bit SHA-1 HMAC of this byte string.  */
@@ -110,7 +111,7 @@ internal actual constructor(
   /** Returns the 512-bit SHA-512 HMAC of this byte string.  */
   open fun hmacSha512(key: ByteString) = hmac("HmacSHA512", key)
 
-  private fun hmac(algorithm: String, key: ByteString): ByteString {
+  internal open fun hmac(algorithm: String, key: ByteString): ByteString {
     try {
       val mac = Mac.getInstance(algorithm)
       mac.init(SecretKeySpec(key.toByteArray(), algorithm))
@@ -230,16 +231,7 @@ internal actual constructor(
       fromIndex)
 
   @JvmOverloads
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/native/src/main/kotlin/okio/ByteString.kt
+++ b/okio/native/src/main/kotlin/okio/ByteString.kt
@@ -31,6 +31,7 @@ import okio.internal.commonHashCode
 import okio.internal.commonHex
 import okio.internal.commonIndexOf
 import okio.internal.commonInternalArray
+import okio.internal.commonLastIndexOf
 import okio.internal.commonOf
 import okio.internal.commonRangeEquals
 import okio.internal.commonStartsWith
@@ -150,19 +151,9 @@ internal actual constructor(
 
   // TODO move lastIndexOf() when https://youtrack.jetbrains.com/issue/KT-22818 is fixed
 
-  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(),
-    fromIndex)
+  fun lastIndexOf(other: ByteString, fromIndex: Int = size) = lastIndexOf(other.internalArray(), fromIndex)
 
-  open fun lastIndexOf(other: ByteArray, fromIndex: Int = size): Int {
-    var fromIndex = fromIndex
-    fromIndex = minOf(fromIndex, data.size - other.size)
-    for (i in fromIndex downTo 0) {
-      if (arrayRangeEquals(data, i, other, 0, other.size)) {
-        return i
-      }
-    }
-    return -1
-  }
+  fun lastIndexOf(other: ByteArray, fromIndex: Int = size) = commonLastIndexOf(other, fromIndex)
 
   actual override fun equals(other: Any?) = commonEquals(other)
 

--- a/okio/src/main/kotlin/okio/internal/ByteString.kt
+++ b/okio/src/main/kotlin/okio/internal/ByteString.kt
@@ -37,7 +37,7 @@ internal fun ByteString.commonUtf8(): String {
   var result = utf8
   if (result == null) {
     // We don't care if we double-allocate in racy code.
-    result = data.toUtf8String()
+    result = internalArray().toUtf8String()
     utf8 = result
   }
   return result
@@ -171,6 +171,16 @@ internal fun ByteString.commonEndsWith(suffix: ByteArray) =
 internal fun ByteString.commonIndexOf(other: ByteArray, fromIndex: Int): Int {
   val limit = data.size - other.size
   for (i in maxOf(fromIndex, 0)..limit) {
+    if (arrayRangeEquals(data, i, other, 0, other.size)) {
+      return i
+    }
+  }
+  return -1
+}
+
+internal fun ByteString.commonLastIndexOf(other: ByteArray, fromIndex: Int): Int {
+  val limit = data.size - other.size
+  for (i in minOf(fromIndex, limit) downTo 0) {
     if (arrayRangeEquals(data, i, other, 0, other.size)) {
       return i
     }


### PR DESCRIPTION
* Only convert ByteString to array once for Buffer.indexOf

* Extract common segment processing in SegmentedByteString

* Only calculate the UTF-8 string once for SegmentedByteString

* Use the segments of data for digest and HMAC calculations

* Allow sharing of segments for substrings of SegmentedByteString

* Delegate to rangeEquals when performing indexOf and lastIndexOf

* Use forEachSegment as function name

* Revert indexOf refactoring as it is slower

* Add performance test for SegmentedByteString